### PR TITLE
Fix bug on rendering elements at the console's width and height

### DIFF
--- a/src/Canvas/ConsoleCanvas.cs
+++ b/src/Canvas/ConsoleCanvas.cs
@@ -20,9 +20,9 @@ namespace TerminalSnake.Canvas
             BrushColor = CanvasColor.Green;
         }
 
-        public int Width => Console.BufferWidth;
+        public int Width => Console.BufferWidth - 1;
 
-        public int Height => Console.BufferHeight;
+        public int Height => Console.BufferHeight - 1;
 
         public CanvasColor FillColor { get => Console.BackgroundColor.ToCanvasColor(); set => Console.BackgroundColor = value.ToConsoleColor(); }
         public CanvasColor BrushColor { get => Console.ForegroundColor.ToCanvasColor(); set => Console.ForegroundColor = value.ToConsoleColor(); }
@@ -38,8 +38,11 @@ namespace TerminalSnake.Canvas
         public void Draw(int x, int y, object? drawable = null)
         {
             if (Resized())
+            {
+                Clear();
                 throw new CanvasResizedException();
-            if (x > Width || y > Height)
+            }
+            if (x < 0 || y < 0 || x > Width || y > Height)
                 throw new PointOutOfCanvasBoundsException(this, x, y);
             Console.SetCursorPosition(x, y);
 

--- a/src/TerminalSnakeGame.cs
+++ b/src/TerminalSnakeGame.cs
@@ -32,7 +32,7 @@ namespace TerminalSnake
                 Console.ResetColor();
                 Console.CursorVisible = true;
             }
-            Console.SetCursorPosition(0, Console.BufferHeight);
+            Console.SetCursorPosition(0, Console.BufferHeight - 1);
             Console.WriteLine();
         }
 
@@ -74,26 +74,26 @@ namespace TerminalSnake
                 const string msg = "Press any key to continue...";
                 _canvas.FillColor = CanvasColor.Black;
                 _canvas.BrushColor = CanvasColor.Green;
-                _canvas.Draw(_canvas.Width / 2 - msg.Length / 2, _canvas.Height, msg);
+                _canvas.Draw(_canvas.Width / 2 - msg.Length / 2, _canvas.Height - 1, msg);
                 while (!keyListeningTask.IsCompleted) ;
             }
         }
 
-        private static void PrintGameOver(string? message = null)
+        private void PrintGameOver(string? message = null)
         {
             const string gameOverMessage = "     Game Over     ";
-            int x = Console.BufferWidth / 2 - gameOverMessage.Length / 2;
-            int y = Console.BufferHeight / 2;
-            Console.SetCursorPosition(x, y);
-            Console.BackgroundColor = ConsoleColor.Red;
-            Console.ForegroundColor = ConsoleColor.White;
-            Console.Write(gameOverMessage);
+            int x = _canvas.Width / 2 - gameOverMessage.Length / 2;
+            int y = _canvas.Height / 2;
+
+            _canvas.FillColor = CanvasColor.Red;
+            _canvas.BrushColor = CanvasColor.White;
+            _canvas.Draw(x, y, gameOverMessage);
 
             if (message == null)
                 return;
 
             x = Console.BufferWidth / 2 - message.Length / 2;
-            Console.SetCursorPosition(x, ++y);
+            Console.SetCursorPosition(x > 0 ? x : 0, ++y);
             Console.BackgroundColor = ConsoleColor.Black;
             Console.ForegroundColor = ConsoleColor.Red;
             Console.Write(message);


### PR DESCRIPTION
- ensure that the width and height are never drawn on since it crashes on Windows Terminal
- improve error validation and message printing

closes #2 